### PR TITLE
Basic AWS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ WORKDIR /go/src/github.com/ernestio/network-adapter
 
 RUN make deps && go install
 
-ENTRYPOINT /go/bin/network-adapter
+ENTRYPOINT ./entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+echo "Waiting for NATS"
+while ! echo exit | nc nats 4222; do sleep 1; done
+
+echo "Waiting for Postgres"
+while ! echo exit | nc postgres 5432; do sleep 1; done
+
+echo "Starting network-adapter"
+/go/bin/network-adapter

--- a/main.go
+++ b/main.go
@@ -48,10 +48,10 @@ func main() {
 		Client:     nc,
 		ValidTypes: getConnectorTypes("networks"),
 	}
-
+	t := Translator{}
 	log.Println("Setting up networks")
-	o.StandardSubscription(&c, "network.create", "router_type")
-	o.StandardSubscription(&c, "network.delete", "router_type")
+	o.TranslatedSubscription(&c, "network.create", "router_type", t)
+	o.TranslatedSubscription(&c, "network.delete", "router_type", t)
 
 	runtime.Goexit()
 }

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func getConnectorTypes(ctype string) []string {
 	return connectors[ctype]
 }
 
-func main() {
+func setup() {
 	nc = ecc.NewConfig(os.Getenv("NATS_URI")).Nats()
 
 	c := o.Config{
@@ -50,8 +50,11 @@ func main() {
 	}
 	t := Translator{}
 	log.Println("Setting up networks")
-	o.TranslatedSubscription(&c, "network.create", "router_type", t)
-	o.TranslatedSubscription(&c, "network.delete", "router_type", t)
+	o.TranslatedSubscription(&c, "network.create", "_type", t)
+	o.TranslatedSubscription(&c, "network.delete", "_type", t)
+}
 
+func main() {
+	setup()
 	runtime.Goexit()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -52,7 +52,7 @@ func TestBasicRedirections(t *testing.T) {
 		n.Subscribe("network.create.vcloud", func(msg *nats.Msg) {
 			chvcl <- true
 		})
-		n.Subscribe("network.create.fake-aws", func(msg *nats.Msg) {
+		n.Subscribe("network.create.aws-fake", func(msg *nats.Msg) {
 			chvfaws <- true
 		})
 		n.Subscribe("network.create.aws", func(msg *nats.Msg) {
@@ -94,8 +94,8 @@ func TestBasicRedirections(t *testing.T) {
 			})
 		})
 
-		Convey("When it receives a valid fake-aws message", func() {
-			n.Publish("network.create", []byte(`{"_batch_id":"a","_uuid":"c","service":"aaa","router_type":"fake-aws","range":"10.1.1.10/24","datacenter_region":"r","datacenter_access_token":"t","datacenter_access_key":"k","datacenter_name":"n","network_subnet":"ns"}`))
+		Convey("When it receives a valid aws-fake message", func() {
+			n.Publish("network.create", []byte(`{"_batch_id":"a","_uuid":"c","service":"aaa","router_type":"aws-fake","range":"10.1.1.10/24","datacenter_region":"r","datacenter_access_token":"t","datacenter_access_key":"k","datacenter_name":"n","network_subnet":"ns"}`))
 			Convey("Then it should redirect it to a fake connector", func() {
 				So(wait(chvfaws), ShouldBeNil)
 			})

--- a/main_test.go
+++ b/main_test.go
@@ -31,17 +31,17 @@ func waitTime(ch chan bool, timeout time.Duration) error {
 
 func TestBasicRedirections(t *testing.T) {
 	n := ecc.NewConfig(os.Getenv("NATS_URI")).Nats()
+	n.Subscribe("config.get.connectors", func(msg *nats.Msg) {
+		n.Publish(msg.Reply, []byte(`{"networks":["fake","vcloud","aws","aws-fake","vcloud-fake"]}`))
+	})
+	setup()
 
 	Convey("Given this service is fully set up", t, func() {
 		chfak := make(chan bool)
 		cherr := make(chan bool)
 		chvcl := make(chan bool)
-
-		n.Subscribe("config.get.connectors", func(msg *nats.Msg) {
-			n.Publish(msg.Reply, []byte(`{"executions":["fake","salt"],"firewalls":["fake","vcloud"],"instances":["fake","vcloud"],"nats":["fake","vcloud"],"networks":["fake","vcloud"],"routers":["fake","vcloud"]}`))
-		})
-
-		go main()
+		chvfaws := make(chan bool)
+		chvaws := make(chan bool)
 
 		n.Subscribe("network.create.fake", func(msg *nats.Msg) {
 			chfak <- true
@@ -52,22 +52,52 @@ func TestBasicRedirections(t *testing.T) {
 		n.Subscribe("network.create.vcloud", func(msg *nats.Msg) {
 			chvcl <- true
 		})
+		n.Subscribe("network.create.fake-aws", func(msg *nats.Msg) {
+			chvfaws <- true
+		})
+		n.Subscribe("network.create.aws", func(msg *nats.Msg) {
+			chvaws <- true
+		})
+
+		n.Subscribe("network.create.aws", func(msg *nats.Msg) {
+			ex := `{"_batch_id":"a","_type":"aws","_uuid":"c","datacenter_access_key":"k","datacenter_access_token":"t","datacenter_region":"r","datacenter_vpc_id":"n","network_subnet":"ns"}`
+			if ex == string(msg.Data) {
+				chvaws <- true
+			}
+		})
+
 		Convey("When it receives an invalid fake message", func() {
 			n.Publish("network.create", []byte(`{"service":"aaa"}`))
-			Convey("Then it should redirect it to a fake connector", func() {
-				So(wait(cherr), ShouldNotBeNil)
+			Convey("Then it should redirect to network error creation", func() {
+				So(wait(cherr), ShouldBeNil)
 			})
 		})
+
 		Convey("When it receives a valid fake message", func() {
-			n.Publish("network.create", []byte(`{"service":"aaa","router_type":"fake"}`))
+			n.Publish("network.create", []byte(`{"service":"aaa","router_type":"fake","range":"10.1.1.10/24"}`))
 			Convey("Then it should redirect it to a fake connector", func() {
 				So(wait(chfak), ShouldBeNil)
 			})
 		})
+
 		Convey("When it receives a valid vcloud message", func() {
-			n.Publish("network.create", []byte(`{"service":"aaa","router_type":"vcloud"}`))
+			n.Publish("network.create", []byte(`{"service":"aaa","router_type":"vcloud","range":"10.1.1.10/24"}`))
 			Convey("Then it should redirect it to a fake connector", func() {
 				So(wait(chvcl), ShouldBeNil)
+			})
+		})
+
+		Convey("When it receives a valid aws message", func() {
+			n.Publish("network.create", []byte(`{"_batch_id":"a","_uuid":"c","service":"aaa","router_type":"aws","range":"10.1.1.10/24","datacenter_region":"r","datacenter_access_token":"t","datacenter_access_key":"k","datacenter_name":"n","network_subnet":"ns"}`))
+			Convey("Then it should redirect it to a fake connector", func() {
+				So(wait(chvaws), ShouldBeNil)
+			})
+		})
+
+		Convey("When it receives a valid fake-aws message", func() {
+			n.Publish("network.create", []byte(`{"_batch_id":"a","_uuid":"c","service":"aaa","router_type":"fake-aws","range":"10.1.1.10/24","datacenter_region":"r","datacenter_access_token":"t","datacenter_access_key":"k","datacenter_name":"n","network_subnet":"ns"}`))
+			Convey("Then it should redirect it to a fake connector", func() {
+				So(wait(chvfaws), ShouldBeNil)
 			})
 		})
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -88,14 +88,14 @@ func TestBasicRedirections(t *testing.T) {
 		})
 
 		Convey("When it receives a valid aws message", func() {
-			n.Publish("network.create", []byte(`{"_batch_id":"a","_uuid":"c","service":"aaa","router_type":"aws","range":"10.1.1.10/24","datacenter_region":"r","datacenter_access_token":"t","datacenter_access_key":"k","datacenter_name":"n","network_subnet":"ns"}`))
+			n.Publish("network.create", []byte(`{"_batch_id":"a","_uuid":"c","service":"aaa","network_type":"aws","range":"10.1.1.10/24","datacenter_region":"r","datacenter_access_token":"t","datacenter_access_key":"k","datacenter_name":"n","network_subnet":"ns"}`))
 			Convey("Then it should redirect it to a fake connector", func() {
 				So(wait(chvaws), ShouldBeNil)
 			})
 		})
 
 		Convey("When it receives a valid aws-fake message", func() {
-			n.Publish("network.create", []byte(`{"_batch_id":"a","_uuid":"c","service":"aaa","router_type":"aws-fake","range":"10.1.1.10/24","datacenter_region":"r","datacenter_access_token":"t","datacenter_access_key":"k","datacenter_name":"n","network_subnet":"ns"}`))
+			n.Publish("network.create", []byte(`{"_batch_id":"a","_uuid":"c","service":"aaa","network_type":"aws-fake","range":"10.1.1.10/24","datacenter_region":"r","datacenter_access_token":"t","datacenter_access_key":"k","datacenter_name":"n","network_subnet":"ns"}`))
 			Convey("Then it should redirect it to a fake connector", func() {
 				So(wait(chvfaws), ShouldBeNil)
 			})

--- a/translator.go
+++ b/translator.go
@@ -144,7 +144,7 @@ func (t Translator) builderToAwsConnector(input builderEvent) []byte {
 	output.DatacenterAccessToken = input.DatacenterAccessToken
 	output.DatacenterAccessKey = input.DatacenterAccessKey
 	output.DatacenterVpcID = input.DatacenterName
-	output.NetworkSubnet = input.NetworkSubnet
+	output.NetworkSubnet = input.Range
 	output.NetworkAWSID = input.NetworkAWSID
 
 	body, _ := json.Marshal(output)

--- a/translator.go
+++ b/translator.go
@@ -89,12 +89,10 @@ func (t Translator) BuilderToConnector(j []byte) []byte {
 	var output []byte
 	json.Unmarshal(j, &input)
 
-	println(input.RouterType)
-
 	switch input.RouterType {
-	case "vcloud", "fake-vcloud", "fake":
+	case "vcloud", "vcloud-fake", "fake":
 		output = t.builderToVCloudConnector(input)
-	case "aws", "fake-aws":
+	case "aws", "aws-fake":
 		output = t.builderToAwsConnector(input)
 	}
 
@@ -157,9 +155,9 @@ func (t Translator) ConnectorToBuilder(j []byte) []byte {
 	dec.Decode(&input)
 
 	switch input["_type"] {
-	case "vcloud", "fake-vcloud", "fake":
+	case "vcloud", "vcloud-fake", "fake":
 		output = t.vcloudConnectorToBuilder(j)
-	case "aws", "fake-aws":
+	case "aws", "aws-fake":
 		output = t.awsConnectorToBuilder(j)
 	}
 

--- a/translator.go
+++ b/translator.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -10,35 +11,41 @@ import (
 )
 
 type builderEvent struct {
-	Uuid               string   `json:"_uuid"`
-	BatchID            string   `json:"_batch_id"`
-	Type               string   `json:"type"`
-	Name               string   `json:"name"`
-	Range              string   `json:"range"`
-	Subnet             string   `json:"subnet,omitempty"`
-	Netmask            string   `json:"netmask,omitempty"`
-	StartAddress       string   `json:"start_address,omitempty"`
-	EndAddress         string   `json:"end_address,omitempty"`
-	Gateway            string   `json:"gateway,omitempty"`
-	DNS                []string `json:"dns"`
-	Router             string   `json:"router"`
-	RouterType         string   `json:"router_type"`
-	RouterName         string   `json:"router_name,omitempty"`
-	ClientName         string   `json:"client_name"`
-	DatacenterType     string   `json:"datacenter_type,omitempty"`
-	DatacenterName     string   `json:"datacenter_name,omitempty"`
-	DatacenterUsername string   `json:"datacenter_username,omitempty"`
-	DatacenterPassword string   `json:"datacenter_password,omitempty"`
-	VCloudURL          string   `json:"vcloud_url"`
-	Status             string   `json:"status"`
-	ErrorCode          string   `json:"error_code"`
-	ErrorMessage       string   `json:"error_message"`
+	Uuid                  string   `json:"_uuid"`
+	BatchID               string   `json:"_batch_id"`
+	Type                  string   `json:"type"`
+	Name                  string   `json:"name"`
+	Service               string   `json:"service"`
+	Range                 string   `json:"range"`
+	Subnet                string   `json:"subnet,omitempty"`
+	Netmask               string   `json:"netmask,omitempty"`
+	StartAddress          string   `json:"start_address,omitempty"`
+	EndAddress            string   `json:"end_address,omitempty"`
+	Gateway               string   `json:"gateway,omitempty"`
+	DNS                   []string `json:"dns"`
+	Router                string   `json:"router"`
+	RouterType            string   `json:"router_type"`
+	RouterName            string   `json:"router_name,omitempty"`
+	ClientName            string   `json:"client_name"`
+	DatacenterType        string   `json:"datacenter_type,omitempty"`
+	DatacenterName        string   `json:"datacenter_name,omitempty"`
+	DatacenterUsername    string   `json:"datacenter_username,omitempty"`
+	DatacenterPassword    string   `json:"datacenter_password,omitempty"`
+	DatacenterRegion      string   `json:"datacenter_region"`
+	DatacenterAccessToken string   `json:"datacenter_token"`
+	DatacenterAccessKey   string   `json:"datacenter_secret"`
+	NetworkSubnet         string   `json:"network_subnet"`
+	NetworkAWSID          string   `json:"network_aws_id"`
+	VCloudURL             string   `json:"vcloud_url"`
+	Status                string   `json:"status"`
+	ErrorCode             string   `json:"error_code"`
+	ErrorMessage          string   `json:"error_message"`
 }
 
 type vcloudEvent struct {
 	Uuid                string   `json:"_uuid"`
 	BatchID             string   `json:"_batch_id"`
-	Type                string   `json:"type"`
+	Type                string   `json:"_type"`
 	Service             string   `json:"service"`
 	NetworkType         string   `json:"network_type"`
 	NetworkName         string   `json:"network_name"`
@@ -48,7 +55,7 @@ type vcloudEvent struct {
 	NetworkGateway      string   `json:"network_gateway"`
 	DNS                 []string `json:"network_dns"`
 	RouterName          string   `json:"router_name"`
-	RouterType          string   `json:"router_type,omitempty"`
+	RouterType          string   `json:"router_type"`
 	RouterIP            string   `json:"router_ip"`
 	ClientName          string   `json:"client_name,omitempty"`
 	DatacenterType      string   `json:"datacenter_type,omitempty"`
@@ -59,18 +66,49 @@ type vcloudEvent struct {
 	VCloudURL           string   `json:"vcloud_url"`
 }
 
+type awsEvent struct {
+	Uuid                  string `json:"_uuid"`
+	BatchID               string `json:"_batch_id"`
+	Type                  string `json:"_type"`
+	Service               string `json:"service"`
+	DatacenterRegion      string `json:"datacenter_region,omitempty"`
+	DatacenterAccessToken string `json:"datacenter_access_token,omitempty"`
+	DatacenterAccessKey   string `json:"datacenter_access_key,omitempty"`
+	DatacenterVpcID       string `json:"datacenter_vpc_id,omitempty"`
+	NetworkSubnet         string `json:"network_subnet"`
+	NetworkAWSID          string `json:"network_aws_id"`
+	DatacenterName        string `json:"datacenter_name,omitempty"`
+	DatacenterUsername    string `json:"datacenter_username,omitempty"`
+	DatacenterPassword    string `json:"datacenter_password,omitempty"`
+}
+
 type Translator struct{}
 
 func (t Translator) BuilderToConnector(j []byte) []byte {
 	var input builderEvent
+	var output []byte
+	json.Unmarshal(j, &input)
+
+	println(input.RouterType)
+
+	switch input.RouterType {
+	case "vcloud", "fake-vcloud", "fake":
+		output = t.builderToVCloudConnector(input)
+	case "aws", "fake-aws":
+		output = t.builderToAwsConnector(input)
+	}
+
+	return output
+}
+
+func (t Translator) builderToVCloudConnector(input builderEvent) []byte {
 	var output vcloudEvent
 
-	json.Unmarshal(j, &input)
 	octets := getIPOctets(input.Range)
-
 	output.Uuid = input.Uuid
 	output.BatchID = input.BatchID
-	output.Type = input.Type
+	output.Type = input.RouterType
+	output.Service = input.Service
 	output.RouterName = input.RouterName
 	output.RouterType = input.RouterType
 	output.NetworkType = input.RouterType
@@ -88,18 +126,55 @@ func (t Translator) BuilderToConnector(j []byte) []byte {
 	output.NetworkGateway = octets + ".1"
 
 	body, _ := json.Marshal(output)
+
+	return body
+}
+
+func (t Translator) builderToAwsConnector(input builderEvent) []byte {
+	var output awsEvent
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.Service = input.Service
+	output.Type = input.RouterType
+	output.DatacenterRegion = input.DatacenterRegion
+	output.DatacenterAccessToken = input.DatacenterAccessToken
+	output.DatacenterAccessKey = input.DatacenterAccessKey
+	output.DatacenterVpcID = input.DatacenterName
+	output.NetworkSubnet = input.NetworkSubnet
+	output.NetworkAWSID = input.NetworkAWSID
+
+	body, _ := json.Marshal(output)
+
 	return body
 }
 
 func (t Translator) ConnectorToBuilder(j []byte) []byte {
+	var output []byte
+	var input map[string]interface{}
+
+	dec := json.NewDecoder(bytes.NewReader(j))
+	dec.Decode(&input)
+
+	switch input["_type"] {
+	case "vcloud", "fake-vcloud", "fake":
+		output = t.vcloudConnectorToBuilder(j)
+	case "aws", "fake-aws":
+		output = t.awsConnectorToBuilder(j)
+	}
+
+	return output
+}
+
+func (t Translator) vcloudConnectorToBuilder(j []byte) []byte {
 	var input vcloudEvent
 	var output builderEvent
-
 	json.Unmarshal(j, &input)
 
 	output.Uuid = input.Uuid
 	output.BatchID = input.BatchID
 	output.Type = input.Type
+	output.Service = input.Service
 	output.RouterName = input.RouterName
 	output.RouterType = input.RouterType
 	output.Name = input.NetworkName
@@ -116,6 +191,27 @@ func (t Translator) ConnectorToBuilder(j []byte) []byte {
 	output.Gateway = input.NetworkGateway
 
 	body, _ := json.Marshal(output)
+
+	return body
+}
+
+func (t Translator) awsConnectorToBuilder(j []byte) []byte {
+	var input awsEvent
+	var output builderEvent
+	json.Unmarshal(j, &input)
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.Type = input.Type
+	output.DatacenterRegion = input.DatacenterRegion
+	output.DatacenterAccessToken = input.DatacenterAccessToken
+	output.DatacenterAccessKey = input.DatacenterAccessKey
+	output.DatacenterName = input.DatacenterVpcID
+	output.NetworkSubnet = input.NetworkSubnet
+	output.NetworkAWSID = input.NetworkAWSID
+
+	body, _ := json.Marshal(output)
+
 	return body
 }
 

--- a/translator.go
+++ b/translator.go
@@ -82,6 +82,7 @@ type awsEvent struct {
 	DatacenterName        string `json:"datacenter_name,omitempty"`
 	DatacenterUsername    string `json:"datacenter_username,omitempty"`
 	DatacenterPassword    string `json:"datacenter_password,omitempty"`
+	ErrorMessage          string `json:"error"`
 }
 
 type Translator struct{}
@@ -212,6 +213,12 @@ func (t Translator) awsConnectorToBuilder(j []byte) []byte {
 	output.DatacenterName = input.DatacenterVpcID
 	output.NetworkSubnet = input.NetworkSubnet
 	output.NetworkAWSID = input.NetworkAWSID
+
+	if input.ErrorMessage != "" {
+		output.Status = "errored"
+		output.ErrorCode = "0"
+		output.ErrorMessage = input.ErrorMessage
+	}
 
 	body, _ := json.Marshal(output)
 

--- a/translator.go
+++ b/translator.go
@@ -75,6 +75,7 @@ type awsEvent struct {
 	DatacenterAccessToken string `json:"datacenter_access_token,omitempty"`
 	DatacenterAccessKey   string `json:"datacenter_access_key,omitempty"`
 	DatacenterVpcID       string `json:"datacenter_vpc_id,omitempty"`
+	NetworkType           string `json:"network_type"`
 	NetworkSubnet         string `json:"network_subnet"`
 	NetworkAWSID          string `json:"network_aws_id"`
 	DatacenterName        string `json:"datacenter_name,omitempty"`
@@ -134,7 +135,7 @@ func (t Translator) builderToAwsConnector(input builderEvent) []byte {
 	output.Uuid = input.Uuid
 	output.BatchID = input.BatchID
 	output.Service = input.Service
-	output.Type = input.RouterType
+	output.Type = input.NetworkType
 	output.DatacenterRegion = input.DatacenterRegion
 	output.DatacenterAccessToken = input.DatacenterAccessToken
 	output.DatacenterAccessKey = input.DatacenterAccessKey

--- a/translator.go
+++ b/translator.go
@@ -94,6 +94,9 @@ func (t Translator) BuilderToConnector(j []byte) []byte {
 	switch input.RouterType {
 	case "vcloud", "vcloud-fake", "fake":
 		output = t.builderToVCloudConnector(input)
+	}
+
+	switch input.NetworkType {
 	case "aws", "aws-fake":
 		output = t.builderToAwsConnector(input)
 	}

--- a/translator.go
+++ b/translator.go
@@ -34,6 +34,7 @@ type builderEvent struct {
 	DatacenterRegion      string   `json:"datacenter_region"`
 	DatacenterAccessToken string   `json:"datacenter_token"`
 	DatacenterAccessKey   string   `json:"datacenter_secret"`
+	NetworkType           string   `json:"network_type"`
 	NetworkSubnet         string   `json:"network_subnet"`
 	NetworkAWSID          string   `json:"network_aws_id"`
 	VCloudURL             string   `json:"vcloud_url"`

--- a/translator.go
+++ b/translator.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"strings"
+)
+
+type builderEvent struct {
+	Uuid               string   `json:"_uuid"`
+	BatchID            string   `json:"_batch_id"`
+	Type               string   `json:"type"`
+	Name               string   `json:"name"`
+	Range              string   `json:"range"`
+	Subnet             string   `json:"subnet,omitempty"`
+	Netmask            string   `json:"netmask,omitempty"`
+	StartAddress       string   `json:"start_address,omitempty"`
+	EndAddress         string   `json:"end_address,omitempty"`
+	Gateway            string   `json:"gateway,omitempty"`
+	DNS                []string `json:"dns"`
+	Router             string   `json:"router"`
+	RouterType         string   `json:"router_type"`
+	RouterName         string   `json:"router_name,omitempty"`
+	ClientName         string   `json:"client_name"`
+	DatacenterType     string   `json:"datacenter_type,omitempty"`
+	DatacenterName     string   `json:"datacenter_name,omitempty"`
+	DatacenterUsername string   `json:"datacenter_username,omitempty"`
+	DatacenterPassword string   `json:"datacenter_password,omitempty"`
+	VCloudURL          string   `json:"vcloud_url"`
+	Status             string   `json:"status"`
+	ErrorCode          string   `json:"error_code"`
+	ErrorMessage       string   `json:"error_message"`
+}
+
+type vcloudEvent struct {
+	Uuid                string   `json:"_uuid"`
+	BatchID             string   `json:"_batch_id"`
+	Type                string   `json:"type"`
+	Service             string   `json:"service"`
+	NetworkType         string   `json:"network_type"`
+	NetworkName         string   `json:"network_name"`
+	NetworkNetmask      string   `json:"network_netmask"`
+	NetworkStartAddress string   `json:"network_start_address"`
+	NetworkEndAddress   string   `json:"network_end_address"`
+	NetworkGateway      string   `json:"network_gateway"`
+	DNS                 []string `json:"network_dns"`
+	RouterName          string   `json:"router_name"`
+	RouterType          string   `json:"router_type,omitempty"`
+	RouterIP            string   `json:"router_ip"`
+	ClientName          string   `json:"client_name,omitempty"`
+	DatacenterType      string   `json:"datacenter_type,omitempty"`
+	DatacenterName      string   `json:"datacenter_name,omitempty"`
+	DatacenterUsername  string   `json:"datacenter_username,omitempty"`
+	DatacenterPassword  string   `json:"datacenter_password,omitempty"`
+	DatacenterRegion    string   `json:"datacenter_region,omitempty"`
+	VCloudURL           string   `json:"vcloud_url"`
+}
+
+type Translator struct{}
+
+func (t Translator) BuilderToConnector(j []byte) []byte {
+	var input builderEvent
+	var output vcloudEvent
+
+	json.Unmarshal(j, &input)
+	octets := getIPOctets(input.Range)
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.Type = input.Type
+	output.RouterName = input.RouterName
+	output.RouterType = input.RouterType
+	output.NetworkType = input.RouterType
+	output.NetworkName = input.Name
+	output.ClientName = input.ClientName
+	output.DatacenterName = input.DatacenterName
+	output.DatacenterUsername = input.DatacenterUsername
+	output.DatacenterPassword = input.DatacenterPassword
+	output.DatacenterType = input.DatacenterType
+	output.VCloudURL = input.VCloudURL
+	output.DNS = input.DNS
+	output.NetworkNetmask = ParseNetmask(input.Range)
+	output.NetworkStartAddress = octets + ".5"
+	output.NetworkEndAddress = octets + ".250"
+	output.NetworkGateway = octets + ".1"
+
+	body, _ := json.Marshal(output)
+	return body
+}
+
+func (t Translator) ConnectorToBuilder(j []byte) []byte {
+	var input vcloudEvent
+	var output builderEvent
+
+	json.Unmarshal(j, &input)
+
+	output.Uuid = input.Uuid
+	output.BatchID = input.BatchID
+	output.Type = input.Type
+	output.RouterName = input.RouterName
+	output.RouterType = input.RouterType
+	output.Name = input.NetworkName
+	output.ClientName = input.ClientName
+	output.DatacenterName = input.DatacenterName
+	output.DatacenterUsername = input.DatacenterUsername
+	output.DatacenterPassword = input.DatacenterPassword
+	output.DatacenterType = input.DatacenterType
+	output.VCloudURL = input.VCloudURL
+	output.DNS = input.DNS
+	output.Netmask = input.NetworkNetmask
+	output.StartAddress = input.NetworkStartAddress
+	output.EndAddress = input.NetworkEndAddress
+	output.Gateway = input.NetworkGateway
+
+	body, _ := json.Marshal(output)
+	return body
+}
+
+func getIPOctets(rng string) string {
+	// Splits the network range and returns the first three octets
+	ip, _, err := net.ParseCIDR(rng)
+	if err != nil {
+		log.Println(err)
+	}
+	octets := strings.Split(ip.String(), ".")
+	octets = append(octets[:3], octets[3+1:]...)
+	octetString := strings.Join(octets, ".")
+	return octetString
+}
+
+func ParseNetmask(r string) string {
+	// Convert netmask hex to string, generated from network range CIDR
+	_, nw, _ := net.ParseCIDR(r)
+	hx, _ := hex.DecodeString(nw.Mask.String())
+	netmask := fmt.Sprintf("%v.%v.%v.%v", hx[0], hx[1], hx[2], hx[3])
+	return netmask
+}


### PR DESCRIPTION
Adapters were conceived as the place to prepare an internal service to be consumed by a connector, so connectors can focus only on calling third party apis.

However they are quite dummy at the moment, they only get a message and redirect it to the consumer related to the provider.

The behaviour implemented here is:
- Have defined a connector mapping for each connector they support.
- Receive a message "component.process" with the related component partial of the service as this one.
- Call connector with a "component.process.provider"
- Receive a "component.process.provider.done" and map the result back to the partial of the service.
- And finally publish "component.process.done" with mapped partial.
